### PR TITLE
Add web control panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,15 @@ export MONGO_CONNECTION_STRING="mongodb://localhost:27017"
 
 ## Running with Docker Compose
 
-The repository includes a `docker-compose.yml` file that sets up MongoDB and the OpenF1 API.
+The repository includes a `docker-compose.yml` file that sets up MongoDB and starts the OpenF1 control panel.
 After installing [Docker](https://docs.docker.com/get-docker/) run:
 
 ```bash
 docker compose up --build
 ```
 
-The API will be available at [http://localhost:8000](http://localhost:8000).
+The control panel will be available at [http://localhost:9876](http://localhost:9876).
+Start the "Query API" service from the panel to access the API at [http://localhost:9877](http://localhost:9877).
 
 ## Supporting OpenF1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,12 @@ services:
 
   openf1-api:
     build: .
-    command: uvicorn openf1.services.query_api.app:app --host 0.0.0.0 --port 8000
+    command: uvicorn openf1.services.web_control.app:app --host 0.0.0.0 --port 8000
     environment:
       - MONGO_CONNECTION_STRING=mongodb://mongo:27017
     ports:
       - "9876:8000"
+      - "9877:8001"
     depends_on:
       - mongo
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ slowapi>=0.1.9
 tqdm>=4.66.5
 typer>=0.12.5
 uvicorn[standard]>=0.31.0
+Jinja2>=3.1.0
+python-multipart>=0.0.5

--- a/src/openf1/services/query_api/README.md
+++ b/src/openf1/services/query_api/README.md
@@ -13,3 +13,6 @@ uvicorn openf1.services.query_api.app:app --reload
 ```
 
 Make a query in the browser: http://127.0.0.1:8000/v1/meetings?year>=2024
+
+When running through Docker Compose and the control panel, the API will be
+available on `http://localhost:9877` after starting the service from the panel.

--- a/src/openf1/services/web_control/README.md
+++ b/src/openf1/services/web_control/README.md
@@ -1,0 +1,14 @@
+# Web Control Panel
+
+This module exposes a very small web interface that can start or stop the
+main OpenF1 services.
+
+## Running
+
+Start the panel with `uvicorn`:
+
+```bash
+uvicorn openf1.services.web_control.app:app --reload
+```
+
+Open `http://127.0.0.1:8000` in a browser to access the control panel.

--- a/src/openf1/services/web_control/README.md
+++ b/src/openf1/services/web_control/README.md
@@ -11,4 +11,6 @@ Start the panel with `uvicorn`:
 uvicorn openf1.services.web_control.app:app --reload
 ```
 
-Open `http://127.0.0.1:8000` in a browser to access the control panel.
+Open `http://127.0.0.1:8000` in a browser to access the control panel. When run
+inside Docker Compose, the panel is available at `http://localhost:9876` and the
+Query API starts on port `9877`.

--- a/src/openf1/services/web_control/app.py
+++ b/src/openf1/services/web_control/app.py
@@ -13,7 +13,14 @@ templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
 
 # Commands used to launch the services.
 SERVICES: dict[str, list[str]] = {
-    "query_api": ["uvicorn", "openf1.services.query_api.app:app"],
+    "query_api": [
+        "uvicorn",
+        "openf1.services.query_api.app:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8001",
+    ],
     "ingestor_real_time": ["python", "-m", "openf1.services.ingestor_livetiming.real_time.app"],
     "ingestor_historical": ["python", "-m", "openf1.services.ingestor_livetiming.historical.main"],
 }

--- a/src/openf1/services/web_control/templates/index.html
+++ b/src/openf1/services/web_control/templates/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>OpenF1 Control Panel</title>
+</head>
+<body>
+    <h1>OpenF1 Control Panel</h1>
+    <table border="1" cellspacing="0" cellpadding="4">
+        <tr>
+            <th>Service</th>
+            <th>Status</th>
+            <th>Action</th>
+        </tr>
+        {% for name, running in services.items() %}
+        <tr>
+            <td>{{ name }}</td>
+            <td>{{ 'running' if running else 'stopped' }}</td>
+            <td>
+                <form method="post" action="/control">
+                    <input type="hidden" name="name" value="{{ name }}">
+                    {% if running %}
+                    <input type="hidden" name="action" value="stop">
+                    <input type="submit" value="Stop">
+                    {% else %}
+                    <input type="hidden" name="action" value="start">
+                    <input type="submit" value="Start">
+                    {% endif %}
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `web_control` service for managing other services via a web UI
- document how to run the web control panel
- update requirements with `Jinja2` and `python-multipart`

## Testing
- `python -m py_compile src/openf1/services/web_control/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc859df5c832a9072c1ee8a576d6c