### PR TITLE
Fix historical ingestor launch command

### DIFF
--- a/src/openf1/services/web_control/README.md
+++ b/src/openf1/services/web_control/README.md
@@ -14,3 +14,6 @@ uvicorn openf1.services.web_control.app:app --reload
 Open `http://127.0.0.1:8000` in a browser to access the control panel. When run
 inside Docker Compose, the panel is available at `http://localhost:9876` and the
 Query API starts on port `9877`.
+
+By default, the "ingestor_historical" service ingests data for season `2024`.
+Set the `OPENF1_HISTORICAL_SEASON` environment variable to override this year.

--- a/src/openf1/services/web_control/app.py
+++ b/src/openf1/services/web_control/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import os
 from pathlib import Path
 
 from fastapi import FastAPI, Form, Request
@@ -10,6 +11,9 @@ from loguru import logger
 
 
 templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+
+# Year used when ingesting historical data via the control panel.
+HISTORICAL_YEAR = os.getenv("OPENF1_HISTORICAL_SEASON", "2024")
 
 # Commands used to launch the services.
 SERVICES: dict[str, list[str]] = {
@@ -21,8 +25,18 @@ SERVICES: dict[str, list[str]] = {
         "--port",
         "8001",
     ],
-    "ingestor_real_time": ["python", "-m", "openf1.services.ingestor_livetiming.real_time.app"],
-    "ingestor_historical": ["python", "-m", "openf1.services.ingestor_livetiming.historical.main"],
+    "ingestor_real_time": [
+        "python",
+        "-m",
+        "openf1.services.ingestor_livetiming.real_time.app",
+    ],
+    "ingestor_historical": [
+        "python",
+        "-m",
+        "openf1.services.ingestor_livetiming.historical.main",
+        "ingest-season",
+        HISTORICAL_YEAR,
+    ],
 }
 
 # Running processes keyed by service name.


### PR DESCRIPTION
## Summary
- add a default season to run the historical ingestor
- mention `OPENF1_HISTORICAL_SEASON` in control panel docs

## Testing
- `ruff check --output-format=github --ignore=E501 --target-version=py310 src/openf1/services/web_control/app.py`
- `black --check --diff --color src/openf1/services/web_control/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684ceb904e5c832aaa306cbe91fabdd8