### PR TITLE
Add year selection to control panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ docker compose up --build
 
 The control panel will be available at [http://localhost:9876](http://localhost:9876).
 Start the "Query API" service from the panel to access the API at [http://localhost:9877](http://localhost:9877).
+You can also set the desired season year for historical ingestion directly from the panel.
 
 ## Supporting OpenF1
 

--- a/src/openf1/services/web_control/README.md
+++ b/src/openf1/services/web_control/README.md
@@ -17,3 +17,5 @@ Query API starts on port `9877`.
 
 By default, the "ingestor_historical" service ingests data for season `2024`.
 Set the `OPENF1_HISTORICAL_SEASON` environment variable to override this year.
+You can also specify the desired season directly from the control panel before
+starting the service.

--- a/src/openf1/services/web_control/templates/index.html
+++ b/src/openf1/services/web_control/templates/index.html
@@ -23,6 +23,9 @@
                     <input type="submit" value="Stop">
                     {% else %}
                     <input type="hidden" name="action" value="start">
+                    {% if name == 'ingestor_historical' %}
+                    <input type="number" name="year" value="{{ historical_year }}" placeholder="Year" style="width:6em" />
+                    {% endif %}
                     <input type="submit" value="Start">
                     {% endif %}
                 </form>


### PR DESCRIPTION
## Summary
- let the web control panel start the historical ingestor with a chosen season
- document the new capability in README files

## Testing
- `ruff check src/openf1/services/web_control/app.py`
- `ruff check .` *(fails: E722 do not use bare except)*

------
https://chatgpt.com/codex/tasks/task_e_684f9540ee60832a899fea072913c230