### PR TITLE
Use safe literal eval for real time ingestion

### DIFF
--- a/src/openf1/services/ingestor_livetiming/real_time/processing.py
+++ b/src/openf1/services/ingestor_livetiming/real_time/processing.py
@@ -1,4 +1,5 @@
 import asyncio
+import ast
 import json
 import os
 
@@ -19,7 +20,7 @@ _session_key = None
 
 
 def _parse_message(line: str) -> Message:
-    topic, content, timepoint = eval(line)
+    topic, content, timepoint = ast.literal_eval(line)
 
     if isinstance(content, str):
         content = decode(content)


### PR DESCRIPTION
## Summary
- parse real-time messages using `ast.literal_eval`

## Testing
- `ruff --format=github --ignore=E501,E722 --target-version=py310 .`
- `black --check --diff --color .`


------
https://chatgpt.com/codex/tasks/task_e_685f2d54dfd8832abeac05ffcad4ca0d