### PR TITLE
Use aiofiles for async ingest_file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp>=3.11.13
+aiofiles>=24.1.0
 cachetools>=5.3.3
 fastapi>=0.115.0
 fastf1_livetiming @ git+https://github.com/br-g/fastf1-livetiming.git#egg=fastf1_livetiming

--- a/src/openf1/services/ingestor_livetiming/real_time/processing.py
+++ b/src/openf1/services/ingestor_livetiming/real_time/processing.py
@@ -2,6 +2,8 @@ import asyncio
 import json
 import os
 
+import aiofiles
+
 from loguru import logger
 
 from openf1.services.ingestor_livetiming.core.decoding import decode
@@ -84,18 +86,18 @@ async def ingest_file(filepath: str):
     appended to the file and processes them in real-time.
     """
 
-    with open(filepath, "r") as file:
+    async with aiofiles.open(filepath, "r") as file:
         # Read and ingest existing lines
-        lines = file.readlines()
+        lines = await file.readlines()
         for line in lines:
             await ingest_line(line)
 
         # Move to the end of the file
-        file.seek(0, 2)
+        await file.seek(0, os.SEEK_END)
 
         # Watch for new lines
         while True:
-            line = file.readline()
+            line = await file.readline()
             if not line:
                 await asyncio.sleep(0.1)  # Sleep a bit before trying again
                 continue


### PR DESCRIPTION
## Summary
- update `ingest_file` to rely on `aiofiles` for reading
- add `aiofiles` to runtime requirements

## Testing
- `ruff --format=github --ignore=E501,E722 --target-version=py310 .`
- `black --check --diff --color .`


------
https://chatgpt.com/codex/tasks/task_e_685f2d56fd0c832aae72c8e6c5207da9