### PR TITLE
Add live recorder service

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ docker compose up --build
 The control panel will be available at [http://localhost:9876](http://localhost:9876).
 Start the "Query API" service from the panel to access the API at [http://localhost:9877](http://localhost:9877).
 You can also set the desired season year for historical ingestion directly from the panel.
+The panel additionally exposes a **live_recorder** service which records the raw timing feed, ingests it into MongoDB and stores it locally using the same format as the historical files.
 
 ## Supporting OpenF1
 

--- a/src/openf1/services/ingestor_livetiming/README.md
+++ b/src/openf1/services/ingestor_livetiming/README.md
@@ -3,6 +3,9 @@
 This module receives, processes, and stores F1 live timing data.<br />
 Live timing data can be ingested during a session (cf. [real_time/](real_time/))
 or afterwards (cf. [historical/](historical/)).
+A minimal [live_recorder/](live_recorder/) service is also provided to record
+the raw feed, ingest it into MongoDB and save the messages as `.jsonStream`
+files for later use.
 
 ## Main concepts
 

--- a/src/openf1/services/ingestor_livetiming/live_recorder/README.md
+++ b/src/openf1/services/ingestor_livetiming/live_recorder/README.md
@@ -1,0 +1,17 @@
+# Live Recorder
+
+This utility records live timing data to a file **while ingesting it into MongoDB**.
+The raw file is converted to the same `.jsonStream` format as the official
+historical data and saved under the standard `historical/<year>/<meeting_key>/<session_key>`
+directory so it can be used as a drop-in replacement until the official files
+become available.
+
+## Running
+
+```bash
+python -m openf1.services.ingestor_livetiming.live_recorder.app
+```
+
+The temporary recording is saved under `OPENF1_CACHE_DIR/live_recordings/`. Once
+the run finishes, the data are moved to `OPENF1_CACHE_DIR/historical/<year>/<meeting_key>/<session_key>`
+with one `.jsonStream` file per topic.

--- a/src/openf1/services/ingestor_livetiming/live_recorder/app.py
+++ b/src/openf1/services/ingestor_livetiming/live_recorder/app.py
@@ -1,0 +1,126 @@
+import asyncio
+import ast
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from loguru import logger
+
+from openf1.services.ingestor_livetiming.core.objects import get_topics
+from openf1.services.ingestor_livetiming.real_time.processing import ingest_file
+from openf1.services.ingestor_livetiming.real_time.recording import record_to_file
+from openf1.util.misc import to_datetime
+
+CACHE_DIR = Path(os.getenv("OPENF1_CACHE_DIR", Path.home() / ".cache" / "openf1"))
+RECORDINGS_DIR = CACHE_DIR / "live_recordings"
+TIMEOUT = 10800  # 3 hours
+
+
+def _format_timedelta(delta: timedelta) -> str:
+    total_ms = int(delta.total_seconds() * 1000)
+    hours = total_ms // 3_600_000
+    minutes = (total_ms % 3_600_000) // 60_000
+    seconds = (total_ms % 60_000) // 1000
+    ms = total_ms % 1000
+    return f"{hours}:{minutes:02}:{seconds:02}.{ms:03}"
+
+
+def convert_recording_to_jsonstreams(source: Path) -> Path:
+    """Convert raw fastf1-livetiming output to F1-like jsonStream files.
+
+    Returns the directory containing the converted files."""
+    output_dir = source.with_suffix("")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    handles: dict[str, Path] = {}
+    t0 = None
+    meeting_key = None
+    session_key = None
+    year = None
+
+    with source.open("r") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            topic, content, ts = ast.literal_eval(line)
+            ts_dt = to_datetime(ts)
+            if ts_dt is None:
+                continue
+
+            if topic == "SessionInfo" and isinstance(content, dict):
+                meeting_key = content.get("Meeting", {}).get("Key")
+                session_key = content.get("Key")
+                start = content.get("StartDate")
+                start_dt = to_datetime(start)
+                if start_dt is not None:
+                    year = start_dt.year
+
+            if t0 is None:
+                t0 = ts_dt
+
+            delta = ts_dt - t0
+            line_prefix = _format_timedelta(delta)
+            if isinstance(content, dict):
+                content_str = json.dumps(content, separators=(",", ":"))
+            else:
+                content_str = str(content)
+            fh = handles.get(topic)
+            if fh is None:
+                fh = (output_dir / f"{topic}.jsonStream").open("w")
+                handles[topic] = fh
+            fh.write(f"{line_prefix}{content_str}\r\n")
+
+    for fh in handles.values():
+        fh.close()
+
+    if meeting_key and session_key and year:
+        hist_dir = (
+            CACHE_DIR / "historical" / str(year) / str(meeting_key) / str(session_key)
+        )
+        hist_dir.mkdir(parents=True, exist_ok=True)
+        for fpath in output_dir.iterdir():
+            fpath.rename(hist_dir / fpath.name)
+        output_dir.rmdir()
+        output_dir = hist_dir
+
+    return output_dir
+
+
+async def main():
+    RECORDINGS_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    file_path = RECORDINGS_DIR / f"{timestamp}.txt"
+
+    logger.info(f"Recording raw data to '{file_path}'")
+    tasks = []
+
+    env_topics = os.getenv("OPENF1_LIVE_TOPICS")
+    topics = sorted(list(get_topics()))
+    if env_topics:
+        allowed = {t.strip() for t in env_topics.split(",") if t.strip()}
+        topics = [t for t in topics if t in allowed]
+
+    task_recording = asyncio.create_task(
+        record_to_file(filepath=str(file_path), topics=topics, timeout=TIMEOUT)
+    )
+    tasks.append(task_recording)
+
+    task_ingest = asyncio.create_task(ingest_file(str(file_path)))
+    tasks.append(task_ingest)
+
+    await asyncio.wait([task_recording], return_when=asyncio.FIRST_COMPLETED)
+    logger.info("Recording stopped")
+
+    logger.info("Stopping tasks")
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+    logger.info("Job completed")
+
+    logger.info("Converting recording to jsonStream format")
+    convert_recording_to_jsonstreams(file_path)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/openf1/services/web_control/README.md
+++ b/src/openf1/services/web_control/README.md
@@ -3,7 +3,9 @@
 This module exposes a very small web interface that can start or stop the
 main OpenF1 services.
 It also lets you choose which topics are recorded by the collectors and which
-API endpoints are exposed.
+API endpoints are exposed. The panel now includes a *live recorder* service
+that stores raw timing data locally, ingests it into MongoDB and keeps the files
+in the historical layout until the official archives become available.
 
 ## Running
 
@@ -21,6 +23,12 @@ By default, the "ingestor_historical" service ingests data for season `2024`.
 Set the `OPENF1_HISTORICAL_SEASON` environment variable to override this year.
 You can also specify the desired season directly from the control panel before
 starting the service.
+
+The panel exposes an additional "live_recorder" service that records the raw
+live timing feed. Each run ingests the data into MongoDB and stores the
+resulting `.jsonStream` files under
+`OPENF1_CACHE_DIR/historical/<year>/<meeting_key>/<session_key>` as a
+temporary backup until Formula 1 publishes its files.
 
 The panel exposes settings to select the topics recorded by both collectors as
 well as the list of available API endpoints. These settings are stored in the

--- a/src/openf1/services/web_control/app.py
+++ b/src/openf1/services/web_control/app.py
@@ -41,6 +41,11 @@ BASE_SERVICES: dict[str, list[str]] = {
         "-m",
         "openf1.services.ingestor_livetiming.real_time.app",
     ],
+    "live_recorder": [
+        "python",
+        "-m",
+        "openf1.services.ingestor_livetiming.live_recorder.app",
+    ],
     "ingestor_historical": [
         "python",
         "-m",


### PR DESCRIPTION
## Summary
- introduce `live_recorder` service for recording raw live timing
- document how to launch the new service
- hook new service into web control panel
- mention the service in project documentation
- store recordings using the `.jsonStream` format
- automatically ingest and store recordings under `historical/<year>/<meeting_key>/<session_key>`

## Testing
- `ruff check --output-format=github --ignore=E501,E722 --target-version=py310 .`
- `black --check --diff --color .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6868ad8a5104832aba678756a0bd837d